### PR TITLE
feat: clear counter on counts update and use previous duration to compute new duration instead of current

### DIFF
--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -1,0 +1,25 @@
+name: Go Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.23'
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: go test -v ./...


### PR DESCRIPTION
Implementation changes:
- clear counts when the duration is updated(both dec and inc)
- check interval expiration before generating new timeout
- use the duration that timedout to compute the new duration instead of the current duration. If current value is changed more drastically, ignore the change for that timeout.