### PR TITLE
Feat/pseudo client queue

### DIFF
--- a/ring/ring.go
+++ b/ring/ring.go
@@ -57,8 +57,21 @@ func (rb *RingBuffer[T]) GetLast() T {
 	return rb.buffer[lastIndex]
 }
 
+// GetSecondLast retrieves the second-to-last element from the buffer.
+// If the buffer has fewer than two elements, it returns the zero value of the type.
+func (rb *RingBuffer[T]) GetSecondLast() T {
+	var zero T // Zero value for type T
+	if rb.count < 2 {
+		return zero // Not enough elements to retrieve the second-to-last
+	}
+
+	// Get the index of the second-to-last element
+	secondLastIndex := (rb.start + rb.count - 2) % rb.size
+	return rb.buffer[secondLastIndex]
+}
+
 // AverageNonZero calculates the average of non-zero elements in the buffer.
-func (rb *RingBuffer[T]) AverageNonZero() float64 {
+func (rb *RingBuffer[T]) AverageNonZero() T {
 	sum := T(0)
 	nonZeroCount := 0
 
@@ -73,5 +86,5 @@ func (rb *RingBuffer[T]) AverageNonZero() float64 {
 	if nonZeroCount == 0 {
 		return 0 // Avoid division by zero
 	}
-	return float64(sum) / float64(nonZeroCount)
+	return sum / T(nonZeroCount)
 }

--- a/rto/rto.go
+++ b/rto/rto.go
@@ -2,6 +2,7 @@
 package rto
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"sync"
@@ -12,17 +13,15 @@ import (
 )
 
 const (
-	DEFAULT_BACKOFF      int64         = 2
-	CONSERVATIVE_BACKOFF int64         = 1
-	DEFAULT_K_MARGIN     int64         = 1
-	DEFAULT_INTERVAL     time.Duration = 5 * time.Second
-	DEFAULT_SLO          float64       = 0.1
-	ALPHA_SCALING        int64         = 8
-	LOG2_ALPHA           int64         = 3
-	BETA_SCALING         int64         = 4
-	LOG2_BETA            int64         = 2
-	SLO_SAFETY_MARGIN    float64       = 0.5 // safety margin of 0.5 or division by 2
-	MIN_FAILED_SAMPLES   float64       = 2
+	DEFAULT_K_MARGIN   int64         = 1
+	DEFAULT_INTERVAL   time.Duration = 5 * time.Second
+	ALPHA_SCALING      int64         = 8
+	LOG2_ALPHA         int64         = 3
+	BETA_SCALING       int64         = 4
+	LOG2_BETA          int64         = 2
+	SLO_SAFETY_MARGIN  float64       = 0.5 // safety margin of 0.5 or division by 2
+	MIN_FAILED_SAMPLES float64       = 2
+	LOG2_PACING_GAIN   int64         = 3
 )
 
 // DONE(v1.0.14): consider the raional of using negative duration for timedout requests
@@ -41,6 +40,20 @@ const (
 	OVERLOAD
 )
 
+var RequestRateLimitExceeded error = requestRateLimitExceeded{}
+
+type requestRateLimitExceeded struct{}
+
+func (requestRateLimitExceeded) Error() string { return "request rate limit exceeded" }
+
+type ConfigValidationError struct {
+	msg string
+}
+
+func (c ConfigValidationError) Error() string {
+	return fmt.Sprintf("config validation error: msg=%s", c.msg)
+}
+
 type Config struct {
 	Id             string
 	Max            time.Duration // max timeout value allowed
@@ -52,21 +65,21 @@ type Config struct {
 	Logger logger.Logger // optional logger
 }
 
-func (c *Config) Validate() error {
+func (c *Config) Validate() *ConfigValidationError {
 	if c.Logger == nil {
 		c.Logger = logger.NewDefaultLogger()
 	}
 	if c.Id == "" {
-		return fmt.Errorf("Id is required")
+		return &ConfigValidationError{msg: "Id is required"}
 	}
 	if c.Max == 0 {
-		return fmt.Errorf("Max is required")
+		return &ConfigValidationError{msg: "Max is required"}
 	}
 	if c.Min == 0 {
-		return fmt.Errorf("Min is required")
+		return &ConfigValidationError{msg: "Min is required"}
 	}
 	if c.SLOFailureRate == 0 {
-		return fmt.Errorf("SLO is required")
+		return &ConfigValidationError{msg: "SLO is required"}
 	}
 	if c.SLOFailureRate != 0 && c.Interval == 0 {
 		c.Logger.Info("SLO is provided but Interval is not, using the default interval", "interval", DEFAULT_INTERVAL)
@@ -100,18 +113,21 @@ type AdaptoRTOProvider struct {
 	// inflight should be computed by req - recv
 	// failure rate should be computed by failed / recv
 	// these counters are cleared per interval
-	req                  int64     // number of requests sent
-	res                  int64     // number of responses received
-	failed               int64     // number of requests failed
-	carry                int64     // carry over from previous interval
-	intervalStart        time.Time // timestamp of the beginning of the current interval
-	overloadThresholdReq int64     // number of requests sent for the interval that caused state transition from NORMAL to OVERLOAD
-	// TODO: this should be a slice to account for the cases where the max is greater than interval
-	// when max > interval, the previous interval could already have request that is over the capacity,
-	// but because overload can only be declared when response is observed,
-	// if max is greater than interval, the request could have be from more than 1 interval ago
-	/* lastNormalReq  int64                  // req from most recent normal interval */
+	req           int64     // number of requests sent
+	res           int64     // number of responses received
+	failed        int64     // number of requests failed
+	carry         int64     // carry over from previous interval
+	dropped       int64     // number of request dropped due to sending rate control
+	intervalStart time.Time // timestamp of the beginning of the current interval
+
+	// overload states
+	overloadThresholdReq int64         // number of requests sent for the interval that caused state transition from NORMAL to OVERLOAD
+	queueLength          int64         // number of requests SCHEDULED & suspended for their turn
+	sendRateInterval     time.Duration // per request interval for controlling sending rate at 1 / overloadThresholdReq
+	pacingGain           int64         // log2 base to be uses as pacing gain or shringk. e.g. overloadThresholdReq + overloadThresholdReq >> pacingGain
+
 	prevNormalReqs *ring.RingBuffer[int64] // ring buffer for recording previous numPrevNormalReqs reqs samples
+	prevNormalRess *ring.RingBuffer[int64] // ring buffer for recording previous numPrevNormalRess ress samples
 
 	// mutex for synchronizing access to timeout calculation fields
 	mu sync.Mutex
@@ -158,6 +174,12 @@ func NewAdaptoRTOProvider(config Config) *AdaptoRTOProvider {
 		intervalStart: time.Now(),
 		// ring buffer with default size of 2 + ceil(max / inteval)
 		prevNormalReqs: ring.NewRingBuffer[int64](2 + int(math.Ceil(float64(config.Max)/float64(config.Interval)))),
+		prevNormalRess: ring.NewRingBuffer[int64](2 + int(math.Ceil(float64(config.Max)/float64(config.Interval)))),
+
+		overloadThresholdReq: 0,
+		queueLength:          0,
+		sendRateInterval:     0,
+		pacingGain:           LOG2_PACING_GAIN,
 
 		sloFailureRateAdjusted: config.SLOFailureRate * SLO_SAFETY_MARGIN,
 		minSamplesRequired:     MIN_FAILED_SAMPLES / (config.SLOFailureRate * SLO_SAFETY_MARGIN),
@@ -180,6 +202,7 @@ func (arp *AdaptoRTOProvider) resetCounters() {
 	arp.req = 0
 	arp.res = 0
 	arp.failed = 0
+	arp.dropped = 0
 }
 
 // CurrentReq extraporates current number of requests for the past interval using sliding window
@@ -199,6 +222,49 @@ func (arp *AdaptoRTOProvider) CurrentReq() int64 {
 	return int64(math.Round(previousReqEstimate)) + arp.req
 }
 
+// OverloadReq computes the estimate of instantaneous number of request per interval that triggered overload.
+// the reference time for the sliding window is adjusted by the timeout duration that triggered overload.
+func (arp *AdaptoRTOProvider) OverloadReq(overloadedTimeout time.Duration) int64 {
+	lastNormalReq := arp.prevNormalReqs.GetLast()
+
+	relativeTime := time.Since(arp.intervalStart)
+	referenceTime := relativeTime - overloadedTimeout // could be negative
+	if referenceTime <= 0 {
+		referenceTime *= -1
+		// reference time is in the previous window
+		secondLastNormalReq := arp.prevNormalReqs.GetSecondLast()
+		fromLast := float64(lastNormalReq) * float64(arp.interval-referenceTime) / float64(arp.interval)
+		fromSecondLast := float64(secondLastNormalReq) * float64(referenceTime) / float64(arp.interval)
+		arp.logger.Info("overload req computed",
+			"fromLast", fromLast,
+			"fromSecondLast", fromSecondLast,
+		)
+		return int64(math.Round(fromLast + fromSecondLast))
+	}
+	fromThis := float64(arp.req) * float64(referenceTime) / float64(relativeTime)
+	fromLast := float64(lastNormalReq) * float64(arp.interval-referenceTime) / float64(arp.interval)
+	arp.logger.Info("overload req computed",
+		"fromThis", fromThis,
+		"fromLast", fromLast,
+	)
+	return int64(math.Round(fromThis + fromLast))
+}
+
+// OverloadRes computes the estimate of instantaneous goodput per interval.
+// the reference time for the sliding window is the moment this method is called.
+func (arp *AdaptoRTOProvider) CurrentRes() int64 {
+	lastNormalRes := arp.prevNormalRess.GetLast()
+	previousResEstimate := float64(lastNormalRes) * float64(arp.interval-time.Since(arp.intervalStart)) / float64(arp.interval)
+	arp.logger.Debug("current rate computed",
+		"res", arp.res,
+		"lastNormalRes", lastNormalRes,
+		"previousResEstimate", previousResEstimate,
+		"sinceIntervalStart", time.Since(arp.intervalStart),
+		"durationRatio", float64(time.Since(arp.intervalStart))/float64(arp.interval),
+	)
+	return int64(math.Round(previousResEstimate)) + arp.res
+}
+
 // ChokeTimeout handles timeout update when transitioning to overload
 // should lock rto updates
 func (arp *AdaptoRTOProvider) ChokeTimeout() {
@@ -210,8 +276,6 @@ func (arp *AdaptoRTOProvider) ChokeTimeout() {
 	rttvar := (int64(arp.minRtt) >> 1) * BETA_SCALING
 
 	// compute rto with formula for first rtt observed.
-	// use kMargin = 1
-	// TODO: which kMargin should be used here
 	rto := arp.minRtt + time.Duration(DEFAULT_K_MARGIN*rttvar) // because rtt = srtt / 8
 	arp.timeout = min(max(rto, arp.min), arp.max)
 }
@@ -232,7 +296,30 @@ func (arp *AdaptoRTOProvider) onRtt(rtt time.Duration) {
 		arp.logger.Debug("DeadlineExceeded", "rto", rtt)
 	}
 
+	// skip timeout update when overload
 	if arp.state == OVERLOAD {
+		return
+	}
+
+	// Declare overload if max timeout is breached
+	if rtt == arp.max {
+		// declare overload
+		arp.ChokeTimeout()
+		arp.state = OVERLOAD
+
+		// increment so that first interval check is skipped
+		arp.dropped++
+
+		// define threshold using the res count instead of req
+		arp.overloadThresholdReq = arp.CurrentRes()
+		arp.sendRateInterval = arp.interval / time.Duration(arp.overloadThresholdReq)
+		arp.logger.Info("overload detected",
+			"triggerRTO", rtt,
+			"chokedRTO", arp.timeout,
+			"minRtt", arp.minRtt,
+			"overloadThresholdReq", arp.overloadThresholdReq,
+			"sendRateInterval", arp.sendRateInterval,
+		)
 		return
 	}
 
@@ -285,9 +372,10 @@ func (arp *AdaptoRTOProvider) onInterval() {
 	arp.logger.Info("failure rate computed", "fr", fr, "sfr", arp.sfr)
 
 	// handle NORMAL state
+	// adjusting kMargin
 	if arp.state == NORMAL {
 		arp.prevNormalReqs.Add(arp.req)
-		// TODO: how to effectively decrement kMargin
+		arp.prevNormalRess.Add(arp.res)
 		// if the fr for this interval is below threshold, must increment kMargin
 		if fr >= arp.sloFailureRateAdjusted {
 			arp.kMargin++
@@ -304,22 +392,48 @@ func (arp *AdaptoRTOProvider) onInterval() {
 
 	// handle OVERLOAD state
 	// TODO: should consider if this threshold is rationale
-	// TEST: record last req before overload start, and use the average as threshold
-	if arp.overloadThresholdReq < arp.req {
+	// adjusting pacing
+	if arp.dropped > 0 {
 		// stil in overload
-		arp.logger.Info("still in overload", "overloadThresholdReq", arp.overloadThresholdReq, "req", arp.req)
+		if fr >= arp.sloFailureRateAdjusted {
+			// shrink pacing with reduced gain
+			// TODO: this only works when optimum is higher than current estimate
+			// only for load increase and not capacity decrease
+			arp.pacingGain++
+			arp.overloadThresholdReq -= arp.overloadThresholdReq >> arp.pacingGain
+			arp.sendRateInterval = arp.interval / time.Duration(
+				arp.overloadThresholdReq,
+			)
+			arp.logger.Info("still in overload, shrinking pacing", "sendRateInterval", arp.sendRateInterval, "overloadThresholdReq", arp.overloadThresholdReq, "dropped", arp.dropped, "req", arp.req)
+		} else {
+			// gain pacing by x1.125
+			// TODO: consider resetting pacing gain or cycling
+			arp.overloadThresholdReq += arp.overloadThresholdReq >> arp.pacingGain
+			arp.sendRateInterval = arp.interval / time.Duration(
+				arp.overloadThresholdReq,
+			)
+			arp.logger.Info("still in overload, growing pacing", "sendRateInterval", arp.sendRateInterval, "overloadThresholdReq", arp.overloadThresholdReq, "dropped", arp.dropped, "req", arp.req)
+		}
 		return
 	}
 	// undeclare overload
-	arp.logger.Info("overload resolved", "overloadThresholdReq", arp.overloadThresholdReq, "req", arp.req)
+	arp.logger.Info("overload resolved", "overloadThresholdReq", arp.overloadThresholdReq, "dropped", arp.dropped, "req", arp.req)
 	arp.overloadThresholdReq = 0
+	arp.sendRateInterval = 0
+	arp.queueLength = 0
+	arp.pacingGain = LOG2_PACING_GAIN
+
+	// reset timeout computation
+	arp.srtt = 0
+	arp.rttvar = 0
 	arp.state = NORMAL
 }
 
-// calcInflight calculates current inflight requests
+// calcInflight calculates current inflight requests.
 // MUST be called in thread safe manner as it does not lock mu
 func (arp *AdaptoRTOProvider) inflight() int64 {
-	return arp.req - arp.res
+	// make sure to subtract dropped
+	return arp.req - arp.res - arp.dropped
 }
 
 var AdaptoRTOProviders map[string]*AdaptoRTOProvider
@@ -331,7 +445,7 @@ func init() {
 
 // GetTimeout retrieves timeout value using provider with given id in config.
 // if no provider with matching id is found, creates a new provider
-func GetTimeout(config Config) (timeout time.Duration, rttCh chan<- RttSignal, err error) {
+func GetTimeout(ctx context.Context, config Config) (timeout time.Duration, rttCh chan<- RttSignal, err error) {
 	provider, ok := AdaptoRTOProviders[config.Id]
 	if !ok {
 		err := config.Validate()
@@ -342,23 +456,62 @@ func GetTimeout(config Config) (timeout time.Duration, rttCh chan<- RttSignal, e
 		go provider.StartWithSLO()
 		AdaptoRTOProviders[config.Id] = provider
 	}
-	timeout, rttCh = provider.NewTimeout()
+	timeout, rttCh, err = provider.NewTimeout(ctx)
 
-	return timeout, rttCh, nil
+	return timeout, rttCh, err
 }
 
 // NewTimeout returns the current timeout value
-// TODO: currently, timeouts are adjusted for every response and every capacity * interval requests.
-// this means that the timeout cannot quickly adjuste to the sudden increase in requests until they return.
-// consider adjusting the timeout value based on the current inflight
-// could possibly use X = inflight / requestLimt
-// higher the X, it is close to being overloaded
-func (arp *AdaptoRTOProvider) NewTimeout() (timeout time.Duration, rttCh chan<- RttSignal) {
+// pseudo client queue / rate limiting suspends timeout creation during overload
+func (arp *AdaptoRTOProvider) NewTimeout(ctx context.Context) (timeout time.Duration, rttCh chan<- RttSignal, err error) {
 	arp.mu.Lock()
 	defer arp.mu.Unlock()
-
 	arp.req++ // increment req counter
-	return arp.timeout, arp.rttCh
+	rttCh = arp.rttCh
+
+	// if in overload state, compute (max timeout - suspend timeout)
+	// if this is lower than arp.timeout (which should currentely be based on minLatency), return err
+	// suspend timeout should be computed as nextSchedulable - time.Now()
+	// nextSchedulable = schedule interval * requests already in line + time.Now()
+	// suspend = arp.schedulingInterval * arp.queueLength
+	if arp.state == OVERLOAD {
+		suspend := arp.sendRateInterval * time.Duration(arp.queueLength)
+		adjustedTimeout := arp.max - suspend
+		if adjustedTimeout < arp.timeout {
+			arp.dropped++
+			arp.logger.Debug("new timeout dropped",
+				"queueLength", arp.queueLength,
+				"supend", suspend,
+				"dropped", arp.dropped,
+			)
+			return time.Duration(0), rttCh, RequestRateLimitExceeded
+		}
+
+		arp.queueLength++
+
+		// return the timeout without suspending
+		// no need to subtract queueLength to avoid multiplication by zero
+		if suspend == 0 {
+			return arp.timeout, rttCh, nil
+		}
+
+		arp.mu.Unlock() // unlock while suspended
+
+		suspendTimer := time.NewTimer(suspend)
+		select {
+		case <-suspendTimer.C:
+			arp.mu.Lock() // reaquire lock, this wait could add up to suspend
+			arp.queueLength--
+			return adjustedTimeout, rttCh, nil
+		case <-ctx.Done():
+			arp.mu.Lock()
+			arp.queueLength--
+			return time.Duration(0), rttCh, ctx.Err()
+		}
+
+	}
+
+	return arp.timeout, arp.rttCh, nil
 }
 
 // ComputeNewRTO computes new rto based on new rtt
@@ -379,21 +532,38 @@ func (arp *AdaptoRTOProvider) ComputeNewRTO(rtt time.Duration) {
 	}
 
 	rto, srtt, rttvar := jacobsonCalc(int64(rtt), arp.srtt, arp.rttvar, arp.kMargin)
-	rtoD := time.Duration(rto)
+	/* rtoD := time.Duration(rto) */
+
 	// check if max timeout was not breachd
-	if rtoD >= arp.max {
-		// declare overload
-		arp.ChokeTimeout()
-		arp.state = OVERLOAD
-
-		// precompute the threshold
-		arp.overloadThresholdReq = (arp.CurrentReq() + int64(arp.prevNormalReqs.AverageNonZero())) >> 1
-		arp.logger.Info("overload detected", "triggerRTO", rtoD, "chokedRTO", arp.timeout, "minRtt", arp.minRtt, "overloadThresholdReq", arp.overloadThresholdReq)
-		return
-	}
-
+	/* if rtoD >= arp.max { */
+	/* 	// declare overload */
+	/* 	arp.ChokeTimeout() */
+	/* 	arp.state = OVERLOAD */
+	/**/
+	/* 	// increment so that first interval check is skipped */
+	/* 	arp.dropped++ */
+	/**/
+	/* 	// threshold is then calculated as the average between prevNormalReqs and overloadReq */
+	/* 	// use shifted overload reference point */
+	/* 	avgNormalReq := arp.prevNormalReqs.AverageNonZero() */
+	/* 	overloadReq := arp.OverloadReq(rtt) */
+	/* 	arp.overloadThresholdReq = max((avgNormalReq+overloadReq)>>1, 1) */
+	/* 	arp.sendRateInterval = arp.interval / time.Duration(arp.overloadThresholdReq) */
+	/* 	arp.logger.Info("overload detected", */
+	/* 		"triggerRTO", rtoD, */
+	/* 		"chokedRTO", arp.timeout, */
+	/* 		"minRtt", arp.minRtt, */
+	/* 		"overloadThresholdReq", arp.overloadThresholdReq, */
+	/* 		"avgNormalReq", avgNormalReq, */
+	/* 		"overloadReq", overloadReq, */
+	/* 		"sendRateInterval", arp.sendRateInterval, */
+	/* 	) */
+	/* 	return */
+	/* } */
+	/**/
 	// do not update these values when overload is detected
-	arp.timeout = max(time.Duration(rto), arp.min) // no need to check for max because of early return
+	/* arp.timeout = max(time.Duration(rto), arp.min) // no need to check for max because of early return */
+	arp.timeout = min(max(time.Duration(rto), arp.min), arp.max)
 	arp.srtt = srtt
 	arp.rttvar = rttvar
 	arp.logger.Debug("new RTO computed", "rto", arp.timeout.String(), "rtt", rtt.String())

--- a/rto/rto_blackbox_test.go
+++ b/rto/rto_blackbox_test.go
@@ -1,6 +1,7 @@
 package rto_test
 
 import (
+	"context"
 	"math"
 	"math/rand"
 	"sync"
@@ -15,93 +16,6 @@ import (
 type Res struct {
 	rto time.Duration
 	rtt time.Duration
-}
-
-func TestStartWithOutSLO(t *testing.T) {
-	logger := logger.NewDefaultLogger()
-	config := rto.Config{
-		Id:             "test1",
-		Max:            5 * time.Second,
-		Min:            1 * time.Millisecond,
-		SLOFailureRate: 0,
-		Interval:       1 * time.Second,
-	}
-
-	normalRps := 800
-	normalInterval := 1 * time.Second / time.Duration(normalRps)
-	normalRtts := generateParetoSamples(2500, 5.0, 5)
-
-	abnormalRps := 1500
-	abnormalInterval := 1 * time.Second / time.Duration(abnormalRps)
-	abnormalRtts := generateParetoSamples(2000, 5.0, 0.5)
-
-	var wg sync.WaitGroup
-
-	for _, rtt := range normalRtts {
-		time.Sleep(normalInterval)
-		wg.Add(1)
-		go func(rtt float64) {
-			timeout, rttCh, err := rto.GetTimeout(config)
-			assert.NoError(t, err, "Error should be nil for GetTimeout")
-			rttD := time.Duration(rtt) * time.Millisecond
-			if timeout < rttD {
-				time.Sleep(timeout)
-				logger.Error("timeout exceeded", "rto", timeout, "rrtD", rttD.String())
-				rttCh <- -timeout
-				wg.Done()
-			} else {
-				time.Sleep(rttD)
-				rttCh <- rttD
-				wg.Done()
-			}
-		}(rtt)
-	}
-
-	logger.Info("<--------------------------Beginning of Abnormal Load-------------------------->")
-
-	for _, rtt := range abnormalRtts {
-		time.Sleep(abnormalInterval)
-		wg.Add(1)
-		go func(rtt float64) {
-			timeout, rttCh, err := rto.GetTimeout(config)
-			assert.NoError(t, err, "Error should be nil for GetTimeout")
-			rttD := time.Duration(rtt) * time.Millisecond
-			if timeout < rttD {
-				time.Sleep(timeout)
-				logger.Error("timeout exceeded", "rto", timeout, "rrtD", rttD.String())
-				rttCh <- -timeout
-				wg.Done()
-			} else {
-				time.Sleep(rttD)
-				rttCh <- rttD
-				wg.Done()
-			}
-		}(rtt)
-	}
-
-	logger.Info("<--------------------------End of Abnormal Load-------------------------->")
-
-	for _, rtt := range normalRtts {
-		time.Sleep(normalInterval)
-		wg.Add(1)
-		go func(rtt float64) {
-			timeout, rttCh, err := rto.GetTimeout(config)
-			assert.NoError(t, err, "Error should be nil for GetTimeout")
-			rttD := time.Duration(rtt) * time.Millisecond
-			if timeout < rttD {
-				time.Sleep(timeout)
-				logger.Error("timeout exceeded", "rto", timeout, "rrtD", rttD.String())
-				rttCh <- -timeout
-				wg.Done()
-			} else {
-				time.Sleep(rttD)
-				rttCh <- rttD
-				wg.Done()
-			}
-		}(rtt)
-	}
-
-	wg.Wait()
 }
 
 func TestStartWithSLO(t *testing.T) {
@@ -201,6 +115,63 @@ func TestStartWithSLO(t *testing.T) {
 	)
 }
 
+func TestStartOverload(t *testing.T) {
+	logger := logger.NewDefaultLogger()
+	config := rto.Config{
+		Id:             "test1",
+		Max:            100 * time.Millisecond,
+		Min:            1 * time.Millisecond,
+		SLOFailureRate: 0.01,
+		Interval:       5 * time.Second,
+	}
+
+	abnormalRps := 300
+	abnormalInterval := time.Duration(float64(time.Second) / float64(abnormalRps))
+	logger.Info(abnormalInterval.String())
+	abnormalRtts := generateParetoSamples(30000, 5.0, 1.5)
+
+	var wg sync.WaitGroup
+	resCh := make(chan Res)
+
+	total := 0
+	abtotal := 0
+	failed := 0
+	abfailed := 0
+	var rtoSum int64 = 0
+	var rttSum int64 = 0
+	var abrtoSum int64 = 0
+	var abrttSum int64 = 0
+
+	for _, rtt := range abnormalRtts {
+		time.Sleep(abnormalInterval)
+		wg.Add(1)
+		go simulateRequest(t, rtt, config, &wg, resCh)
+	}
+	for range abnormalRtts {
+		res := <-resCh
+		if res.rto <= res.rtt {
+			failed++
+			abfailed++
+		}
+		total++
+		abtotal++
+		rtoSum += res.rto.Milliseconds()
+		rttSum += res.rtt.Milliseconds()
+		abrtoSum += res.rto.Milliseconds()
+		abrttSum += res.rtt.Milliseconds()
+	}
+
+	wg.Wait()
+
+	logger.Info("Complete",
+		"fr", float64(failed)/float64(total),
+		"ab_fr", float64(abfailed)/float64(abtotal),
+		"avg_rtt", float64(rttSum)/float64(total),
+		"avg_rto", float64(rtoSum)/float64(total),
+		"ab_avg_rtt", float64(abrttSum)/float64(abtotal),
+		"ab_avg_rto", float64(abrtoSum)/float64(abtotal),
+	)
+}
 // generateNormalSamples generates a slice of n int64 samples from a normal distribution
 // with a specified mean and standard deviation.
 func generateNormalSamples(n int, mean, std float64) []float64 {
@@ -224,8 +195,15 @@ func generateParetoSamples(n int, scale, shape float64) []float64 {
 }
 
 func simulateRequest(t *testing.T, rtt float64, config rto.Config, wg *sync.WaitGroup, resCh chan<- Res) {
-	timeout, rttCh, err := rto.GetTimeout(config)
-	assert.NoError(t, err, "Error should be nil for GetTimeout")
+	timeout, rttCh, err := rto.GetTimeout(context.Background(), config)
+	if err != nil {
+		if err == rto.RequestRateLimitExceeded {
+			wg.Done()
+			resCh <- Res{rto: timeout, rtt: time.Duration(rtt) * time.Millisecond}
+			return
+		}
+		assert.NoError(t, err, "Error should be nil for GetTimeout")
+	}
 	rttD := time.Duration(rtt) * time.Millisecond
 	if timeout < rttD {
 		time.Sleep(timeout)

--- a/rto/rto_test.go
+++ b/rto/rto_test.go
@@ -1,6 +1,7 @@
 package rto
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -14,7 +15,7 @@ func TestInitialRTTCalculation(t *testing.T) {
 		Min: 50 * time.Millisecond,
 	}
 
-	timeout, rttCh, err := GetTimeout(config)
+	timeout, rttCh, err := GetTimeout(context.Background(), config)
 	assert.NoError(t, err, "Error should be nil for GetTimeout")
 	assert.Equal(t, config.Max, timeout, "Initial timeout should match config max")
 
@@ -44,7 +45,7 @@ func TestRegularRTTUpdates(t *testing.T) {
 		Min: 50 * time.Millisecond,
 	}
 
-	timeout, rttCh, err := GetTimeout(config)
+	timeout, rttCh, err := GetTimeout(context.Background(), config)
 	assert.NoError(t, err, "Error should be nil for GetTimeout")
 	assert.Equal(t, config.Max, timeout, "Initial timeout should match config max")
 
@@ -74,7 +75,7 @@ func TestTimeoutBackoff(t *testing.T) {
 		Min: 50 * time.Millisecond,
 	}
 
-	timeout, rttCh, err := GetTimeout(config)
+	timeout, rttCh, err := GetTimeout(context.Background(), config)
 	assert.NoError(t, err, "Error should be nil for GetTimeout")
 
 	provider := AdaptoRTOProviders[config.Id]
@@ -103,7 +104,7 @@ func TestMinMaxConstraints(t *testing.T) {
 		Min: 500 * time.Millisecond,
 	}
 
-	_, rttCh, err := GetTimeout(config)
+	_, rttCh, err := GetTimeout(context.Background(), config)
 	assert.NoError(t, err, "Error should be nil for GetTimeout")
 
 	provider := AdaptoRTOProviders[config.Id]

--- a/rto/rto_test.go
+++ b/rto/rto_test.go
@@ -68,35 +68,6 @@ func TestRegularRTTUpdates(t *testing.T) {
 	provider.mu.Unlock()
 }
 
-func TestTimeoutBackoff(t *testing.T) {
-	config := Config{
-		Id:  "test3",
-		Max: 5 * time.Second,
-		Min: 50 * time.Millisecond,
-	}
-
-	timeout, rttCh, err := GetTimeout(context.Background(), config)
-	assert.NoError(t, err, "Error should be nil for GetTimeout")
-
-	provider := AdaptoRTOProviders[config.Id]
-
-	// Send an RTT measurement
-	rttCh <- 100 * time.Millisecond
-	time.Sleep(50 * time.Millisecond)
-	provider.mu.Lock()
-	expectedBackoffTimeout := min(config.Max, provider.timeout*time.Duration(DEFAULT_BACKOFF))
-	provider.mu.Unlock()
-
-	// Send a DeadlineExceeded signal to test backoff
-	rttCh <- -timeout
-
-	time.Sleep(50 * time.Millisecond)
-	// Check if timeout was backed off correctly
-	provider.mu.Lock()
-	assert.Equal(t, expectedBackoffTimeout, provider.timeout, "Timeout should be backed off correctly on deadline exceeded")
-	provider.mu.Unlock()
-}
-
 func TestMinMaxConstraints(t *testing.T) {
 	config := Config{
 		Id:  "test4",


### PR DESCRIPTION
Implemented psedo client queueing with adaptive timeout and suspend.

**Implementation Detail:**
- when a request with max timeout times out, overload is declared
  - the threshold is computed by taking the number of successful responses with sliding window
  - timeout is choked with minimum rtt for the first 3 intervals of the overload (srtt & rttvar is still recorded)
    - after that, timeout is updated with srtt and rttvar, and half of max timeout
  - during overload, pacing is adjusted based on the failure rate for the interval
    - if the failure rate is below SLO, pacing is increased by about 3%
    - if the failure rate is above SLO, pacing is reduced to most recent successful response count