### PR TITLE
Stabilize timeout generation

### DIFF
--- a/rto/jacobson.go
+++ b/rto/jacobson.go
@@ -1,0 +1,16 @@
+package rto
+
+func jacobsonCalc(R, prevSrtt, prevRttvar, margin int64) (rto, srtt, rttvar int64) {
+	err := R - (prevSrtt >> LOG2_ALPHA) // R = R - (srtt / 8)
+	srtt = prevSrtt + err               // srtt = srtt + R - (srtt / 8)
+	if err < 0 {
+		err = -err
+	}
+	err = err - (prevRttvar >> LOG2_BETA) // R = |R - (srtt / 8)| - (rttvar / 4)
+	rttvar = prevRttvar + err             // rttvar = rttvar + |R - (srtt / 8)| - (rttvar / 4)
+
+	// srtt + 4 * rttvar
+	// rttvar must be scaled by 1/4, cancelling out 4
+	rto = (srtt >> LOG2_ALPHA) + margin*rttvar
+	return rto, srtt, rttvar
+}

--- a/rto/rto.go
+++ b/rto/rto.go
@@ -817,7 +817,9 @@ func (arp *AdaptoRTOProvider) OnInterval() {
 		arp.overloadDrainIntervalsRemaining--
 		if arp.overloadDrainIntervalsRemaining == 0 {
 			arp.transitionToOverload()
+
 		}
+		defer arp.resetCounters() // reset counters each interval
 		return
 	case OVERLOAD:
 		if arp.hasEnoughSamples() {


### PR DESCRIPTION
Stabilize timeout generation by updating the timeout less frequently.
The new version of adapto will compute new timeout every interval instead of every RTT. (srtt and rttvar are updated per RTT)
This stablizes the generated timeout values as it will be more likely to use the up to date srtt and rttvar. 

Additionally, for the separation of concerns in the different states of the state machine, the code was refactored around switch statement with the states as cases.

New States, STARTUP, DRAIN, and FAILURE was added to the original OVERLOAD and NORMAL. And NORMAL was renamed as CRUISE.
